### PR TITLE
Change deb package name on readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,7 @@ Else, you can always use these packages on Ubuntu via [Tsuru ppa](https://launch
 
 	% sudo apt-add-repository ppa:tsuru/ppa
 	% sudo apt-get update
-	% sudo apt-get install tsuru
+	% sudo apt-get install tsuru-client
 
 ### Debian wheezy (7.x stable)
 
@@ -44,7 +44,7 @@ Debian wheezy APT source list:
 Run ``apt-get update``, you can install ``tsuru`` for Debian:
 
 	% sudo apt-get update
-	% sudo apt-get install tsuru
+	% sudo apt-get install tsuru-client
 
 ##Building locally
 


### PR DESCRIPTION
Tsuru debian packages where beeing referenced as `tsuru` but it doesn't exit. Changed to `tsuru-client` so at least the mentioned command `apt-get install` works.
